### PR TITLE
nom complet NULL dans v_userslist_forall_menu

### DIFF
--- a/data/usershub.sql
+++ b/data/usershub.sql
@@ -305,7 +305,7 @@ CREATE OR REPLACE VIEW v_userslist_forall_menu AS
     a.identifiant,
     a.nom_role,
     a.prenom_role,
-    (upper(a.nom_role::text) || ' '::text) || a.prenom_role::text AS nom_complet,
+    btrim(concat(upper(a.nom_role::text), ' '::text, a.prenom_role::text)) AS nom_complet,								
     a.desc_role,
     a.pass,
     a.pass_plus,


### PR DESCRIPTION
Permet d'éviter que le nom complet soit NULL si le prénom ou le nom est NULL (ce qui faisait planter le frontend de Occtax)