### PR TITLE
style: use container-fluid on table_database templates

### DIFF
--- a/app/templates/table_database.html
+++ b/app/templates/table_database.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-      <div class="container main-zone ng-scope">
+      <div class="container-fluid main-zone ng-scope">
         <div class="card p-4 mb-3 bg-secondary border border-0 text-white">
           <h2>{{ name_list }}
             {% if key2 %}

--- a/app/templates/temp_users.html
+++ b/app/templates/temp_users.html
@@ -2,7 +2,7 @@
 {% include "head-appli.html" %}
 {% include "alert_messages.html" %} 
 
-<div class="container main-zone ng-scope">
+<div class="container-fluid main-zone ng-scope">
     <div class="card p-4 mb-3 bg-secondary border border-0 text-white">
       <h2>Demandes de compte en cours
 


### PR DESCRIPTION
Table display is often ugly due to large strings in cells or high number of columns, which generate tables biggest than normal container.

Before:
![Capture d’écran 2022-04-28 à 11 05 02](https://user-images.githubusercontent.com/22891423/165718245-4b27caec-e4e4-4d0b-92a8-61f4e90c9080.png)


After:
![Capture d’écran 2022-04-28 à 11 04 39](https://user-images.githubusercontent.com/22891423/165718254-58ba80b8-fb4b-4ede-ad0a-b045e945952f.png)

