### PR TITLE
feat: make scripts portable across unix systems

### DIFF
--- a/install_app.sh
+++ b/install_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . config/settings.ini || exit 1
 

--- a/install_db.sh
+++ b/install_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Make sure root cannot run our script
 if [ "$(id -u)" == "0" ]; then
    echo "This script must NOT be run as root" 1>&2


### PR DESCRIPTION
Permet aux développeurs n'ayant pas le $PATH classique `/bin/bash` (i.e MacOS) de pouvoir executer les scripts d'installation/migration.

Cette notation est plus flexible et permet d'assouplir les restrictions sur l'environnement de développement des collaborateurs.

https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html