### PR TITLE
fix breaking change (caused by flask_login) on password change route 

### DIFF
--- a/app/api/route_register.py
+++ b/app/api/route_register.py
@@ -122,12 +122,15 @@ def valid_temp_user():
     # recherche de l'utilisateur temporaire correspondant au token
     temp_user = db.session.query(TempUser).filter(token == TempUser.token_role).first()
     if not temp_user:
-        return {
-            "msg": f"""
+        return (
+            {
+                "msg": f"""
                 Il n'y a pas d'utilisateur temporaire correspondant au token fourni {token}.<br>
                 Il se peut que la demande de création de compte ai déjà été validée, ou bien que l'adresse de validation soit erronée.<br>
                 """
-        }, 422
+            },
+            422,
+        )
 
     req_data = temp_user.as_dict()
     # Récupération du groupe par défaut
@@ -167,6 +170,7 @@ def set_cor_role_token(email):
     Fonction pour la création d'un token associé a un id_role
     Parametres : email
     """
+
     if not email:
         return {"msg": "Aucun email"}, 404
 
@@ -220,7 +224,6 @@ def create_cor_role_token():
     data = request.get_json()
 
     email = data["email"]
-
     return set_cor_role_token(email)
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -7,10 +7,19 @@ import sys
 import json
 import logging
 from pkg_resources import iter_entry_points
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlencode
 from pathlib import Path
 
-from flask import Flask, redirect, url_for, request, session, render_template, g
+from flask import (
+    Flask,
+    Response,
+    redirect,
+    url_for,
+    request,
+    session,
+    render_template,
+    g,
+)
 from werkzeug.middleware.proxy_fix import ProxyFix
 from sqlalchemy.exc import ProgrammingError
 from flask_migrate import Migrate
@@ -19,6 +28,7 @@ from app.env import db
 
 from pypnusershub.db.models import Application
 from pypnusershub.login_manager import login_manager
+from app.utils.errors import handle_unauthenticated_request
 
 
 migrate = Migrate()
@@ -128,5 +138,7 @@ def create_app():
             app.register_blueprint(
                 route_register.route, url_prefix="/api_register"
             )  # noqa
+
+        app.login_manager.unauthorized_handler(handle_unauthenticated_request)
 
     return app

--- a/app/utils/errors.py
+++ b/app/utils/errors.py
@@ -1,0 +1,33 @@
+from flask import current_app, Response, request, redirect
+from urllib.parse import urlencode
+
+
+# Unauthorized means disconnected
+# (logged but not allowed to perform an action = Forbidden)
+
+
+def handle_unauthenticated_request():
+    """
+    To avoid returning the login page html indicated in `routes_with_no_redirect_login`
+    this function override `LoginManager.unauthorized()` from `flask-login` .
+
+    Returns
+    -------
+    flask.Response
+        response
+    """
+    routes_with_no_redirect_login = [
+        "create_cor_role_token",
+        "test_connexion",
+    ]
+    in_request = [
+        route
+        for route in routes_with_no_redirect_login
+        if route in request.url_rule.rule
+    ]
+    if len(in_request):
+        return Response(response={}, status=401)
+    else:
+        url_redirect = current_app.config["URL_REDIRECT"]
+        query_string = urlencode({"next": request.url})
+        return redirect(f"{url_redirect}?{query_string}")


### PR DESCRIPTION
Flask login redirects automatically to login page when user not authorized. This change cause the password change mecanism of Geonature to break.

Fix with a custom error handler on the LoginManager instantiated by flask_login